### PR TITLE
update volume alert to eight days

### DIFF
--- a/charts/base-services/Chart.yaml
+++ b/charts/base-services/Chart.yaml
@@ -1,3 +1,3 @@
 description: Web 3 platform base services.
 name: base-services
-version: v0.3.7
+version: v0.3.8

--- a/charts/base-services/templates/rules/kubernetes-storage.yaml
+++ b/charts/base-services/templates/rules/kubernetes-storage.yaml
@@ -23,15 +23,15 @@ spec:
       for: 1m
       labels:
         severity: critical
-    - alert: KubePersistentVolumeFullInFourDays
+    - alert: KubePersistentVolumeFullInEightDays
       annotations:
         message: Based on recent sampling, the PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim
-          }}`}} in Namespace {{`{{ $labels.namespace }}`}} is expected to fill up within four
+          }}`}} in Namespace {{`{{ $labels.namespace }}`}} is expected to fill up within eight
           days. Currently {{`{{ $value }}`}} bytes are available.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays
       expr: |
-        kubelet_volume_stats_available_bytes{job="kubelet"} and predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600) < 0
-      for: 5m
+        kubelet_volume_stats_available_bytes{job="kubelet"} and predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 8 * 24 * 3600) < 0
+      for: 30m
       labels:
         severity: critical
 {{ end }}


### PR DESCRIPTION
Towards https://github.com/w3f/infrastructure/issues/141

It also bumps up the `for` field so that we get less false positives because of spikes.