### PR TITLE
Prevent disk alert false positives

### DIFF
--- a/charts/base-services/Chart.yaml
+++ b/charts/base-services/Chart.yaml
@@ -1,4 +1,4 @@
 description: Web 3 platform base services.
 name: base-services
-version: v1.0.0
+version: v1.0.1
 apiVersion: v2

--- a/charts/base-services/templates/rules/kubernetes-storage.yaml
+++ b/charts/base-services/templates/rules/kubernetes-storage.yaml
@@ -33,7 +33,7 @@ spec:
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays
       expr: |
         kubelet_volume_stats_available_bytes{job="kubelet"} and predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 8 * 24 * 3600) < 0
-      for: 30m
+      for: 60m
       labels:
         severity: critical
         origin: {{ .Values.origin }}


### PR DESCRIPTION
This aims to fix the KubePersistentVolumeFullInEightDays flapping alerts we are getting about polkadot harvester redis disk.